### PR TITLE
Feat/openresty log rotation

### DIFF
--- a/ansible/roles/forc_api/tasks/020-openresty.yml
+++ b/ansible/roles/forc_api/tasks/020-openresty.yml
@@ -48,3 +48,26 @@
     state: restarted
     enabled: True
   when: openresty_config is changed
+
+- name: Setup log rotation access.log
+  cron:
+    name: rotate_access_log
+    user: root
+    minute: 0
+    hour: 0
+    day: 1
+    month: *
+    weekday: *
+    job: sudo mv /usr/local/openresty/nginx/logs/access.log /usr/local/openresty/nginx/logs/access.log.0; sudo kill -USR1 `cat /usr/local/openresty/nginx/logs/nginx.pid`
+
+- name: Setup log rotation error.log
+  cron:
+    name: rotate_error_log
+    user: root
+    minute: 0
+    hour: 1
+    day: 1
+    month: *
+    weekday: *
+    job: sudo mv /usr/local/openresty/nginx/logs/error.log /usr/local/openresty/nginx/logs/error.log.0; sudo kill -USR1 `cat /usr/local/openresty/nginx/logs/nginx.pid`
+

--- a/ansible/roles/forc_api/tasks/020-openresty.yml
+++ b/ansible/roles/forc_api/tasks/020-openresty.yml
@@ -53,21 +53,21 @@
   cron:
     name: rotate_access_log
     user: root
-    minute: 0
-    hour: 0
-    day: 1
-    month: *
-    weekday: *
+    minute: "0"
+    hour: "0"
+    day: "1"
+    month: "*"
+    weekday: "*"
     job: sudo mv /usr/local/openresty/nginx/logs/access.log /usr/local/openresty/nginx/logs/access.log.0; sudo kill -USR1 `cat /usr/local/openresty/nginx/logs/nginx.pid`
 
 - name: Setup log rotation error.log
   cron:
     name: rotate_error_log
     user: root
-    minute: 0
-    hour: 1
-    day: 1
-    month: *
-    weekday: *
+    minute: "0"
+    hour: "1"
+    day: "1"
+    month: "*"
+    weekday: "*"
     job: sudo mv /usr/local/openresty/nginx/logs/error.log /usr/local/openresty/nginx/logs/error.log.0; sudo kill -USR1 `cat /usr/local/openresty/nginx/logs/nginx.pid`
 


### PR DESCRIPTION
@vktrrdk 
Setup cronjob to rotate access.log and error.log
inspired by https://www.digitalocean.com/community/tutorials/how-to-configure-logging-and-log-rotation-in-nginx-on-an-ubuntu-vps -> Manual Log Rotation