### PR TITLE
Services: Remove rewrite from webservice (trailing path)

### DIFF
--- a/examples/templates/webservice%v01.conf
+++ b/examples/templates/webservice%v01.conf
@@ -49,7 +49,6 @@ location /{{ key_url }}/ {
         }
 
         # After check via lua-oidc is done, start reverse proxying this backend by configuring a billion headers.
-        rewrite /{{ key_url }}/(.*) /$1 break;
         proxy_pass {{ location_url }};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
@dweinholz

This is regarding the trailing path issue: #579 

In order for web services to run without problems, the trailing path of an URL has to be forwarded to the instance. The removal of the rewrite rule in the webservice config fixes that issue.